### PR TITLE
Adopt Context Sync as persistent-memory backend

### DIFF
--- a/.context-sync/seed.json
+++ b/.context-sync/seed.json
@@ -1,0 +1,9 @@
+{
+  "project": "Juniper",
+  "repo": "bkal169/juniper",
+  "purpose": "Alan's war room + Legacy — autonomous agent runtime.",
+  "memory": [
+    { "type": "note", "content": "Stack: Python agent (cron_main.py, agents/, mcp/), Supabase, deployed on Railway." },
+    { "type": "note", "content": "See HANDOFF.md and WAKEUP.md for operating handoff. vault-init/ seeds agent memory." }
+  ]
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+"context-sync": {
+      "command": "npx",
+      "args": ["-y", "@context-sync/server"],
+      "type": "stdio"
+    }
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
 "context-sync": {
       "command": "npx",
-      "args": ["-y", "@context-sync/server"],
+      "args": ["-y", "-p", "@context-sync/server", "context-sync"],
       "type": "stdio"
     }
   }

--- a/CONTEXT_SYNC.md
+++ b/CONTEXT_SYNC.md
@@ -13,7 +13,7 @@ session ended instead of re-deriving context every time.
 The MCP server is registered in [`.mcp.json`](./.mcp.json):
 
 ```json
-"context-sync": { "command": "npx", "args": ["-y", "@context-sync/server"], "type": "stdio" }
+"context-sync": { "command": "npx", "args": ["-y", "-p", "@context-sync/server", "context-sync"], "type": "stdio" }
 ```
 
 `npx -y` fetches and runs the server on first use — no manual global install
@@ -24,7 +24,21 @@ required. All repos in this fleet share one local store keyed by path; set
 
 `set_project` · `remember` · `recall` · `read_file` · `search` · `structure` · `git` · `notion` (read-only)
 
-## First-session bootstrap
+## First-session bootstrap (auto-init)
+
+Run once per environment to register this repo and seed its memory in one command:
+
+```sh
+sh scripts/context-sync-init.sh        # set_project + install git hooks + remember() the seed
+sh scripts/context-sync-init.sh --dry-run   # validate .context-sync/seed.json without contacting the server
+```
+
+The script drives the MCP server over stdio (the tools are JSON-RPC, not shell
+subcommands), reads structured identity from [`.context-sync/seed.json`](./.context-sync/seed.json),
+calls `set_project`, then `remember`s each entry. Edit `seed.json` to evolve the
+seeded memory; re-run to re-apply.
+
+### Manual equivalent
 
 In a fresh environment, call `set_project({ path: "<absolute path to this repo>" })`
 (this also installs git context-capture hooks), then seed the identity below with

--- a/CONTEXT_SYNC.md
+++ b/CONTEXT_SYNC.md
@@ -1,0 +1,38 @@
+# Context Sync — Memory Backend
+
+This repository uses **[Context Sync](https://github.com/Intina47/context-sync)**
+(`@context-sync/server`) as its local-first persistent-memory backend for AI
+coding assistants (Claude Code, Cursor, Zed, Continue — any MCP client).
+
+Context Sync stores project identity, decisions, constraints, and caveats in a
+local SQLite store keyed by project path, so an agent resumes where the last
+session ended instead of re-deriving context every time.
+
+## Registered server
+
+The MCP server is registered in [`.mcp.json`](./.mcp.json):
+
+```json
+"context-sync": { "command": "npx", "args": ["-y", "@context-sync/server"], "type": "stdio" }
+```
+
+`npx -y` fetches and runs the server on first use — no manual global install
+required. All repos in this fleet share one local store keyed by path; set
+`CONTEXT_SYNC_DB_PATH` to pin a custom location if needed.
+
+## Tools
+
+`set_project` · `remember` · `recall` · `read_file` · `search` · `structure` · `git` · `notion` (read-only)
+
+## First-session bootstrap
+
+In a fresh environment, call `set_project({ path: "<absolute path to this repo>" })`
+(this also installs git context-capture hooks), then seed the identity below with
+`remember` so it persists across sessions.
+
+## Seed identity
+
+- **Project:** Juniper (`bkal169/juniper`)
+- **What it is:** Alan's war room + Legacy — autonomous agent runtime.
+- **Stack:** Python agent (cron_main.py, agents/, mcp/), Supabase, deployed on Railway.
+- **Notes:** See HANDOFF.md and WAKEUP.md for operating handoff. vault-init/ seeds agent memory.

--- a/scripts/context-sync-init.mjs
+++ b/scripts/context-sync-init.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+// Context Sync auto-init: drives the @context-sync/server MCP stdio server to
+// register this project and seed its memory from .context-sync/seed.json.
+//
+// The context-sync tools (set_project, remember, ...) are MCP JSON-RPC tools,
+// not shell subcommands, so we speak newline-delimited JSON-RPC over stdio.
+//
+// Usage: node scripts/context-sync-init.mjs [--repo-root <path>] [--dry-run]
+
+import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function arg(name, fallback) {
+  const i = process.argv.indexOf(name);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+const DRY_RUN = process.argv.includes("--dry-run");
+const REPO_ROOT = resolve(arg("--repo-root", resolve(__dirname, "..")));
+const SEED_PATH = resolve(REPO_ROOT, ".context-sync/seed.json");
+
+const seed = JSON.parse(readFileSync(SEED_PATH, "utf8"));
+const memory = Array.isArray(seed.memory) ? seed.memory : [];
+
+console.log(`[context-sync] repo:    ${seed.repo ?? "(unknown)"}`);
+console.log(`[context-sync] path:    ${REPO_ROOT}`);
+console.log(`[context-sync] purpose: ${seed.purpose ?? "(none)"}`);
+console.log(`[context-sync] memory:  ${memory.length} entries`);
+
+if (DRY_RUN) {
+  console.log("[context-sync] --dry-run: seed parsed OK, not contacting server.");
+  process.exit(0);
+}
+
+// Build the ordered list of tool calls.
+const calls = [
+  { name: "set_project", arguments: { path: REPO_ROOT, purpose: seed.purpose ?? "" } },
+  ...memory.map((m) => ({ name: "remember", arguments: { type: m.type, content: m.content } })),
+];
+
+const child = spawn("npx", ["-y", "-p", "@context-sync/server", "context-sync"], {
+  stdio: ["pipe", "pipe", "inherit"],
+  env: process.env,
+});
+
+let buf = "";
+let sawOutput = false;
+const pending = new Map();
+let nextId = 1;
+
+function send(method, params) {
+  const id = nextId++;
+  const msg = { jsonrpc: "2.0", id, method, params };
+  child.stdin.write(JSON.stringify(msg) + "\n");
+  return new Promise((res, rej) => pending.set(id, { res, rej }));
+}
+function notify(method, params) {
+  child.stdin.write(JSON.stringify({ jsonrpc: "2.0", method, params }) + "\n");
+}
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// The server runs a DB migration and prints non-JSON startup lines before its
+// stdin reader is ready, so initialize can race startup. Retry until answered.
+async function initialize() {
+  for (let i = 0; !sawOutput && i < 50; i++) await sleep(100); // wait for first server output
+  await sleep(300);
+  for (let attempt = 1; attempt <= 4; attempt++) {
+    const id = nextId++;
+    child.stdin.write(JSON.stringify({ jsonrpc: "2.0", id, method: "initialize",
+      params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "context-sync-init", version: "1.0.0" } } }) + "\n");
+    const got = await Promise.race([
+      new Promise((res) => pending.set(id, { res, rej: res })),
+      sleep(3000).then(() => "__timeout__"),
+    ]);
+    pending.delete(id);
+    if (got !== "__timeout__") return got;
+    console.log(`[context-sync]   …initialize retry ${attempt}`);
+  }
+  throw new Error("server did not respond to initialize");
+}
+
+child.stdout.on("data", (chunk) => {
+  sawOutput = true;
+  buf += chunk.toString();
+  let nl;
+  while ((nl = buf.indexOf("\n")) !== -1) {
+    const line = buf.slice(0, nl).trim();
+    buf = buf.slice(nl + 1);
+    if (!line) continue;
+    let msg;
+    try { msg = JSON.parse(line); } catch { continue; } // ignore non-JSON log lines
+    if (msg.id != null && pending.has(msg.id)) {
+      const { res, rej } = pending.get(msg.id);
+      pending.delete(msg.id);
+      msg.error ? rej(new Error(JSON.stringify(msg.error))) : res(msg.result);
+    }
+  }
+});
+
+const fail = (e) => { console.error(`[context-sync] FAILED: ${e?.message ?? e}`); child.kill(); process.exit(1); };
+child.on("error", fail);
+
+(async () => {
+  await send("initialize", {
+    protocolVersion: "2025-06-18",
+    capabilities: {},
+    clientInfo: { name: "context-sync-init", version: "1.0.0" },
+  });
+  notify("notifications/initialized", {});
+
+  for (const c of calls) {
+    const r = await send("tools/call", c);
+    const detail = c.name === "remember" ? `${c.arguments.type}` : "";
+    if (r?.isError) throw new Error(`${c.name} ${detail}: ${JSON.stringify(r.content)}`);
+    console.log(`[context-sync]   ✓ ${c.name}${detail ? " (" + detail + ")" : ""}`);
+  }
+
+  console.log("[context-sync] done — project registered and memory seeded.");
+  child.stdin.end();
+  child.kill();
+  process.exit(0);
+})().catch(fail);

--- a/scripts/context-sync-init.sh
+++ b/scripts/context-sync-init.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+# Thin wrapper: register this project with Context Sync and seed its memory.
+# Requires Node (already a prerequisite of the context-sync MCP server).
+set -e
+DIR="$(cd "$(dirname "$0")" && pwd)"
+exec node "$DIR/context-sync-init.mjs" --repo-root "$(cd "$DIR/.." && pwd)" "$@"


### PR DESCRIPTION
Registers the [`@context-sync/server`](https://github.com/Intina47/context-sync) MCP server as this repo's local-first persistent-memory backend, and documents the adoption.

## What & why
Context Sync gives MCP clients durable memory — project identity, decisions, constraints, caveats — in a local SQLite store keyed by project path. Agents resume prior context instead of re-deriving it each session. Pairs with the existing HANDOFF.md / WAKEUP.md handoff flow.

## Changes
- **`.mcp.json`** — register `context-sync` (`npx -y @context-sync/server`, stdio).
- **`CONTEXT_SYNC.md`** — document adoption, the 8 tools, first-session bootstrap, and this repo's seed identity (Python autonomous agent: cron_main + agents/ + mcp/, Supabase, Railway).

Part of a fleet-wide rollout across all 9 repos. No app code touched.

🤖 Draft for review.

---
_Generated by [Claude Code](https://claude.ai/code/session_017XBjKep3jtrza8LcUzzzDq)_